### PR TITLE
Add setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,20 @@ class Anime
   field :title
   field :url
 end
+```
 
+```ruby
+# Read the field values
 anime = Anime.new({ title: 'The Vampire Dies in No Time', url: 'https://sugushinu-anime.jp/' })
 anime.title #=> 'The Vampire Dies in No Time'
 anime.url #=> 'https://sugushinu-anime.jp/'
+```
+
+```ruby
+# Write the field value
+anime = Anime.new({})
+anime.title = 'The Vampire Dies in No Time'
+anime.title #=> 'The Vampire Dies in No Time'
 ```
 
 If the data contains attributes not declared in the field, it raises no error and is simply ignored.

--- a/README.md
+++ b/README.md
@@ -124,23 +124,31 @@ class Book
   class Company
     include Sumaki::Model
     field :name
-    field :prefecture
   end
 end
+```
 
+```ruby
 data = {
   title: 'The Ronaldo Chronicles',
   company: {
     name: 'Autumn Books',
-    prefecture: 'Tokyo'
   }
 }
 
-comic = Book.new(data)
-comic.company.name #=> 'Autumn Books'
+# Read from the sub object
+book = Book.new(data)
+book.company.name #=> 'Autumn Books'
 ```
 
-sub object is wrapped with the class inferred from the field name under the original class.
+```ruby
+# Build a sub object
+book = Book.new({})
+book.build_company(name: 'Autumn Books')
+book.company #=> #<Book::Company:0x000073a618e31e80 name: "Autumn Books">
+```
+
+Sub object is wrapped with the class inferred from the field name under the original class.
 
 This can be changed by specifying the class to wrap.
 
@@ -182,7 +190,9 @@ class Company
     field :name
   end
 end
+```
 
+```ruby
 data = {
   name: 'The Ronaldo Vampire Hunter Agency',
   member: [
@@ -192,9 +202,17 @@ data = {
   ]
 }
 
+# Read from the sub object
 company = Company.new(data)
 company.member.size #=> 3
 company.member[2].name #=> 'John'
+```
+
+```ruby
+# Build a sub object
+company = Company.new({})
+company.member.build(name: 'John')
+company.member[0].name #=> 'John'
 ```
 
 The `class_name` option can also be used to specify the class to wrap.

--- a/README.md
+++ b/README.md
@@ -255,14 +255,25 @@ class Character
   field :name
   enum :type, { vampire: 1, vampire_hunter: 2, familier: 3, editor: 4 }
 end
+```
 
+```ruby
 data = {
   name: 'John',
   type: 3
 }
 
+# Read the enum
 character = Character.new(data)
-character.type #=> :familier
+character.type.name #=> :familier
+character.type.familier? #=> true
+```
+
+```ruby
+# Write the enum value
+character = Character.new({})
+character.type = 1
+character.type.name #=> :vampire
 ```
 
 

--- a/lib/sumaki/adapter/hash.rb
+++ b/lib/sumaki/adapter/hash.rb
@@ -12,6 +12,10 @@ module Sumaki
         data[key] = value
       end
 
+      def build_singular(data, name)
+        data[name] = {}
+      end
+
       def build_repeated_element(_data, _name)
         {}
       end

--- a/lib/sumaki/adapter/hash.rb
+++ b/lib/sumaki/adapter/hash.rb
@@ -7,6 +7,10 @@ module Sumaki
       def get(data, key)
         data[key]
       end
+
+      def set(data, key, value)
+        data[key] = value
+      end
     end
   end
 end

--- a/lib/sumaki/adapter/hash.rb
+++ b/lib/sumaki/adapter/hash.rb
@@ -11,6 +11,14 @@ module Sumaki
       def set(data, key, value)
         data[key] = value
       end
+
+      def build_repeated_element(_data, _name)
+        {}
+      end
+
+      def apply_repeated(data, name, objects)
+        data[name] = objects
+      end
     end
   end
 end

--- a/lib/sumaki/model.rb
+++ b/lib/sumaki/model.rb
@@ -191,6 +191,10 @@ module Sumaki
         @adapter.set(@object, name, value)
       end
 
+      def build_singular(name)
+        @adapter.build_singular(@object, name)
+      end
+
       def build_repeated_element(name)
         @adapter.build_repeated_element(@object, name)
       end

--- a/lib/sumaki/model.rb
+++ b/lib/sumaki/model.rb
@@ -186,6 +186,10 @@ module Sumaki
       def get(name)
         @adapter.get(@object, name)
       end
+
+      def set(name, value)
+        @adapter.set(@object, name, value)
+      end
     end
 
     module InstanceMethods # :nodoc:
@@ -202,6 +206,10 @@ module Sumaki
 
       def get(name)
         object_accessor.get(name)
+      end
+
+      def set(name, value)
+        object_accessor.set(name, value)
       end
 
       def inspect

--- a/lib/sumaki/model.rb
+++ b/lib/sumaki/model.rb
@@ -177,6 +177,17 @@ module Sumaki
       end
     end
 
+    class ObjectAccessor # :nodoc:
+      def initialize(object, adapter)
+        @object = object
+        @adapter = adapter
+      end
+
+      def get(name)
+        @adapter.get(@object, name)
+      end
+    end
+
     module InstanceMethods # :nodoc:
       attr_reader :object, :parent
 
@@ -185,8 +196,12 @@ module Sumaki
         @parent = parent
       end
 
+      def object_accessor
+        @object_accessor ||= ObjectAccessor.new(object, self.class.adapter)
+      end
+
       def get(name)
-        self.class.adapter.get(object, name)
+        object_accessor.get(name)
       end
 
       def inspect

--- a/lib/sumaki/model.rb
+++ b/lib/sumaki/model.rb
@@ -190,6 +190,14 @@ module Sumaki
       def set(name, value)
         @adapter.set(@object, name, value)
       end
+
+      def build_repeated_element(name)
+        @adapter.build_repeated_element(@object, name)
+      end
+
+      def apply_repeated(name, models)
+        @adapter.apply_repeated(@object, name, models.map(&:object))
+      end
     end
 
     module InstanceMethods # :nodoc:
@@ -210,6 +218,12 @@ module Sumaki
 
       def set(name, value)
         object_accessor.set(name, value)
+      end
+
+      def assign(attrs)
+        attrs.each do |attr, value|
+          public_send(:"#{attr}=", value)
+        end
       end
 
       def inspect

--- a/lib/sumaki/model/associations/association.rb
+++ b/lib/sumaki/model/associations/association.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Sumaki
+  module Model
+    module Associations
+      module Association
+        class Singular # :nodoc:
+          def initialize(owner, reflection)
+            @owner = owner
+            @reflection = reflection
+          end
+
+          def model
+            @model ||= begin
+              object = @owner.get(@reflection.name)
+              object.nil? ? nil : @reflection.model_class.new(object, parent: @owner)
+            end
+          end
+
+          def build_model(attrs = {})
+            assoc = @owner.object_accessor.build_singular(@reflection.name)
+
+            model = @reflection.model_class.new(assoc, parent: @owner)
+            model.assign(attrs)
+
+            @model = model
+          end
+        end
+
+        class Repeated # :nodoc:
+          def initialize(owner, reflection)
+            @owner = owner
+            @reflection = reflection
+          end
+
+          def collection
+            @collection ||= begin
+              objects_or_value = @owner.get(@reflection.name)
+              models = if objects_or_value.is_a?(Array)
+                         model_class = @reflection.model_class
+                         objects_or_value.map { |object| model_class.new(object, parent: @owner) }
+                       else
+                         []
+                       end
+
+              @reflection.collection_class.new(models, owner: @owner)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/associations/collection.rb
+++ b/lib/sumaki/model/associations/collection.rb
@@ -15,6 +15,12 @@ module Sumaki
         def_delegators :@models, :inspect, :pretty_print
         def_delegators 'self.class', :reflection
 
+        def self.build_subclass(reflection)
+          subclass = Class.new(self)
+          subclass.reflection = reflection
+          subclass
+        end
+
         def initialize(models = [], owner:)
           @models = models
           @owner = owner

--- a/lib/sumaki/model/associations/collection.rb
+++ b/lib/sumaki/model/associations/collection.rb
@@ -11,7 +11,7 @@ module Sumaki
 
         singleton_class.attr_accessor :reflection
 
-        def_delegators :@models, :each
+        def_delegators :@models, :each, :[]
         def_delegators :@models, :inspect, :pretty_print
         def_delegators 'self.class', :reflection
 

--- a/lib/sumaki/model/associations/collection.rb
+++ b/lib/sumaki/model/associations/collection.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Sumaki
+  module Model
+    module Associations
+      class Collection # :nodoc:
+        include Enumerable
+        extend Forwardable
+
+        singleton_class.attr_accessor :reflection
+
+        def_delegators :@models, :each
+        def_delegators :@models, :inspect, :pretty_print
+        def_delegators 'self.class', :reflection
+
+        def initialize(models = [], owner:)
+          @models = models
+          @owner = owner
+        end
+
+        def build(attrs = {})
+          object = @owner.object_accessor.build_repeated_element(reflection.name)
+          model = reflection.model_class.new(object, parent: @owner)
+          model.assign(attrs)
+
+          self << model
+
+          model
+        end
+
+        def <<(...)
+          r = @models.<<(...)
+          apply
+          r
+        end
+
+        private
+
+        def apply
+          @owner.object_accessor.apply_repeated(reflection.name, @models)
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/associations/reflection.rb
+++ b/lib/sumaki/model/associations/reflection.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Sumaki
+  module Model
+    module Associations
+      module Reflection
+        class Base # :nodoc:
+          def initialize(owner_class, name, class_name: nil)
+            @owner_class = owner_class
+            @name = name
+            @class_name = class_name
+          end
+
+          def name = @name.to_sym
+
+          def model_class
+            @model_class ||= begin
+              basename = @class_name&.to_s || classify(@name.to_s)
+              klass = if @owner_class.const_defined?(basename)
+                        @owner_class.const_get(basename)
+                      else
+                        @owner_class.const_set(basename, Class.new { include Model })
+                      end
+              klass.parent = @owner_class
+              klass
+            end
+          end
+
+          private
+
+          def classify(str)
+            str.gsub(/([a-z\d]+)_?/) { |_| Regexp.last_match(1).capitalize }
+          end
+        end
+
+        class Singular < Base # :nodoc:
+        end
+
+        class Repeated < Base # :nodoc:
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/associations/reflection.rb
+++ b/lib/sumaki/model/associations/reflection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'collection'
+
 module Sumaki
   module Model
     module Associations
@@ -37,6 +39,17 @@ module Sumaki
         end
 
         class Repeated < Base # :nodoc:
+          def collection_class
+            @collection_class ||= begin
+              class_name = "#{model_class.name[/(\w+)$/]}Collection"
+
+              if @owner_class.const_defined?(class_name)
+                @owner_class.const_get(class_name)
+              else
+                @owner_class.const_set(class_name, Collection.build_subclass(self))
+              end
+            end
+          end
         end
       end
     end

--- a/lib/sumaki/model/associations/reflection.rb
+++ b/lib/sumaki/model/associations/reflection.rb
@@ -28,6 +28,10 @@ module Sumaki
             end
           end
 
+          def association_for(model)
+            self.class.association_class.new(model, self)
+          end
+
           private
 
           def classify(str)
@@ -36,9 +40,12 @@ module Sumaki
         end
 
         class Singular < Base # :nodoc:
+          def self.association_class = Association::Singular
         end
 
         class Repeated < Base # :nodoc:
+          def self.association_class = Association::Repeated
+
           def collection_class
             @collection_class ||= begin
               class_name = "#{model_class.name[/(\w+)$/]}Collection"

--- a/lib/sumaki/model/attribute.rb
+++ b/lib/sumaki/model/attribute.rb
@@ -11,13 +11,26 @@ module Sumaki
 
       module AccessorAdder # :nodoc:
         def add(methods_module, field_name)
+          add_getter(methods_module, field_name)
+          add_setter(methods_module, field_name)
+        end
+
+        def add_getter(methods_module, field_name)
           methods_module.module_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{field_name}       # def title
               get(:'#{field_name}') #   get(:'title')
             end                     # end
           RUBY
         end
-        module_function :add
+
+        def add_setter(methods_module, field_name)
+          methods_module.module_eval <<~RUBY, __FILE__, __LINE__ + 1
+            def #{field_name}=(value)      # def title=(value)
+              set(:'#{field_name}', value) #   set(:'title', value)
+            end                            # end
+          RUBY
+        end
+        module_function :add, :add_getter, :add_setter
       end
 
       module ClassMethods # :nodoc:
@@ -32,6 +45,12 @@ module Sumaki
         #   anime = Anime.new({ title: 'The Vampire Dies in No Time', url: 'https://sugushinu-anime.jp/' })
         #   anime.title #=> 'The Vampire Dies in No Time'
         #   anime.url #=> 'https://sugushinu-anime.jp/'
+        #
+        # The Field value cam be set.
+        #
+        #   anime = Anime.new({})
+        #   anime.title = 'The Vampire Dies in No Time'
+        #   anime.title #=> 'The Vampire Dies in No Time'
         def field(name)
           field_names << name.to_sym
           AccessorAdder.add(attribute_methods_module, name)

--- a/lib/sumaki/model/enum.rb
+++ b/lib/sumaki/model/enum.rb
@@ -15,7 +15,11 @@ module Sumaki
         def get(model, name)
           model.get(name)
         end
-        module_function :get
+
+        def set(model, name, value)
+          model.set(name, value)
+        end
+        module_function :get, :set
       end
 
       module ClassMethods # :nodoc:
@@ -36,6 +40,12 @@ module Sumaki
         #   character.type.name #=> :familier
         #   character.type.familier? #=> true
         #   character.type.vampire? #=> false
+        #
+        # Enum can also be set.
+        #
+        #   character = Character.new({})
+        #   character.type = 1
+        #   character.type.name #=> :vampire
         def enum(name, values)
           super(name, values, adapter: EnumAttrAccessor)
         end

--- a/spec/sumaki/model/associations/association_spec.rb
+++ b/spec/sumaki/model/associations/association_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/associations/association'
 
 RSpec.describe Sumaki::Model::Associations::Association do
   let(:assoc_class) do

--- a/spec/sumaki/model/associations/association_spec.rb
+++ b/spec/sumaki/model/associations/association_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/associations/association'
+
+RSpec.describe Sumaki::Model::Associations::Association do
+  let(:assoc_class) do
+    Class.new do
+      include Sumaki::Model
+      field :field
+    end
+  end
+  let(:owner_class) do
+    klass = Class.new { include Sumaki::Model }
+    klass.const_set(:Assoc, assoc_class)
+    klass
+  end
+
+  describe Sumaki::Model::Associations::Association::Singular do
+    let(:reflection) { Sumaki::Model::Associations::Reflection::Singular.new(owner_class, 'assoc') }
+    let(:association) { described_class.new(owner, reflection) }
+
+    describe '#model' do
+      subject { association.model }
+
+      context "when the association doesn't exist" do # rubocop:disable RSpec/NestedGroups
+        let(:owner) { owner_class.new({}) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'when the association exists' do # rubocop:disable RSpec/NestedGroups
+        let(:owner) { owner_class.new({ assoc: { field: 'field' } }) }
+
+        it { is_expected.to be_an_instance_of(assoc_class) }
+        it { is_expected.to have_attributes(field: 'field') }
+        it { is_expected.to have_attributes(parent: owner) }
+      end
+    end
+
+    describe '#build_model' do
+      subject { association.build_model(field: 'field') }
+
+      let(:owner) { owner_class.new({}) }
+
+      it { is_expected.to be_an_instance_of(assoc_class) }
+      it { is_expected.to have_attributes(field: 'field') }
+      it { is_expected.to have_attributes(parent: owner) }
+    end
+  end
+
+  describe Sumaki::Model::Associations::Association::Repeated do
+    let(:reflection) { Sumaki::Model::Associations::Reflection::Repeated.new(owner_class, 'assoc') }
+    let(:association) { described_class.new(owner, reflection) }
+
+    describe '#collection' do
+      subject { association.collection }
+
+      context "when the association isn't an Array" do # rubocop:disable RSpec/NestedGroups
+        let(:owner) { owner_class.new({}) }
+
+        it { is_expected.to have_attributes(class: (a_value < Sumaki::Model::Associations::Collection)) }
+        it { is_expected.to match([]) }
+      end
+
+      context 'when the association is an Array' do # rubocop:disable RSpec/NestedGroups
+        let(:owner) { owner_class.new({ assoc: [{ field: 'field' }] }) }
+
+        it { is_expected.to have_attributes(class: (a_value < Sumaki::Model::Associations::Collection)) }
+        it { is_expected.to match([an_instance_of(assoc_class).and(have_attributes(field: 'field'))]) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/associations/collection_spec.rb
+++ b/spec/sumaki/model/associations/collection_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/associations/collection'
+
+RSpec.describe Sumaki::Model::Associations::Collection do
+  describe '#build' do
+    subject(:build) { collection.build(assoc_name: 'name') }
+
+    let(:assoc_class) do
+      Class.new do
+        include Sumaki::Model
+
+        field :assoc_name
+      end
+    end
+    let(:owner_class) do
+      klass = Class.new do
+        include Sumaki::Model
+
+        repeated :assoc
+      end
+
+      klass.const_set(:Assoc, assoc_class)
+      klass
+    end
+
+    let(:collection_class) do
+      reflection = Sumaki::Model::Associations::Reflection::Repeated.new(owner_class, 'assoc')
+      Class.new(described_class).tap { _1.reflection = reflection }
+    end
+
+    let(:owner) { owner_class.new({}) }
+    let(:collection) { collection_class.new([], owner: owner) }
+
+    context 'when the association is empty' do
+      it { is_expected.to be_a(assoc_class).and have_attributes(assoc_name: 'name') }
+
+      it do
+        build
+        expect(collection).to match([an_instance_of(assoc_class).and(have_attributes(assoc_name: 'name'))])
+      end
+
+      it do
+        build
+        expect(owner.object).to eq({ assoc: [{ assoc_name: 'name' }] })
+      end
+    end
+
+    context 'when the association has an element' do
+      before do
+        collection.build
+      end
+
+      it { is_expected.to be_a(assoc_class).and have_attributes(assoc_name: 'name') }
+
+      it do # rubocop:disable RSpec/ExampleLength
+        build
+        expect(collection).to match(
+          [
+            an_instance_of(assoc_class).and(have_attributes(assoc_name: nil)),
+            an_instance_of(assoc_class).and(have_attributes(assoc_name: 'name'))
+          ]
+        )
+      end
+
+      it do
+        build
+        expect(owner.object).to eq({ assoc: [{}, { assoc_name: 'name' }] })
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/associations/collection_spec.rb
+++ b/spec/sumaki/model/associations/collection_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/associations/collection'
 
 RSpec.describe Sumaki::Model::Associations::Collection do
   describe '#build' do

--- a/spec/sumaki/model/associations/reflection_spec.rb
+++ b/spec/sumaki/model/associations/reflection_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sumaki::Model::Associations::Reflection do
+  let(:assoc_class) { Class.new { include Sumaki::Model } }
+  let(:owner_class) do
+    klass = Class.new { include Sumaki::Model }
+    klass.const_set(:Assoc, assoc_class)
+    klass
+  end
+
+  describe Sumaki::Model::Associations::Reflection::Singular do
+    describe '#model_class' do
+      subject { reflection.model_class }
+
+      let(:reflection) { described_class.new(owner_class, :assoc, class_name: class_name) }
+
+      context 'when classname is not specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { nil }
+
+        it { is_expected.to eq(assoc_class) }
+        it { is_expected.to have_attributes(parent: owner_class) }
+      end
+
+      context 'when classname is specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { 'Relation' }
+
+        it { is_expected.to have_attributes(name: "#{owner_class}::Relation") }
+        it { is_expected.to have_attributes(parent: owner_class) }
+      end
+    end
+  end
+
+  describe Sumaki::Model::Associations::Reflection::Repeated do
+    let(:reflection) { described_class.new(owner_class, :assoc, class_name: class_name) }
+
+    describe '#model_class' do
+      subject { reflection.model_class }
+
+      context 'when classname is not specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { nil }
+
+        it { is_expected.to eq(assoc_class) }
+        it { is_expected.to have_attributes(parent: owner_class) }
+      end
+
+      context 'when classname is specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { 'Relation' }
+
+        it { is_expected.to have_attributes(name: "#{owner_class}::Relation") }
+        it { is_expected.to have_attributes(parent: owner_class) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/associations/reflection_spec.rb
+++ b/spec/sumaki/model/associations/reflection_spec.rb
@@ -52,5 +52,25 @@ RSpec.describe Sumaki::Model::Associations::Reflection do
         it { is_expected.to have_attributes(parent: owner_class) }
       end
     end
+
+    describe '#collection_class' do
+      subject { reflection.collection_class }
+
+      context 'when class_name is not specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { nil }
+
+        it { is_expected.to be < Sumaki::Model::Associations::Collection }
+        it { is_expected.to have_attributes(name: "#{owner_class}::AssocCollection") }
+        it { is_expected.to have_attributes(reflection: reflection) }
+      end
+
+      context 'when class_name is specified' do # rubocop:disable RSpec/NestedGroups
+        let(:class_name) { 'Relation' }
+
+        it { is_expected.to be < Sumaki::Model::Associations::Collection }
+        it { is_expected.to have_attributes(name: "#{owner_class}::RelationCollection") }
+        it { is_expected.to have_attributes(reflection: reflection) }
+      end
+    end
   end
 end

--- a/spec/sumaki/model/associations_spec.rb
+++ b/spec/sumaki/model/associations_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe Sumaki::Model::Associations do
       expect(wrapped.foo.parent).to be_a(SumakiSingularTest)
     end
 
+    describe '#build_association' do
+      subject(:build) { wrapped.build_foo }
+
+      let(:wrapped) { SumakiSingularTest.new({}) }
+
+      it { is_expected.to be_a(SumakiSingularTest::Foo) }
+
+      it do
+        build
+        expect(wrapped.foo).to be_a(SumakiSingularTest::Foo)
+      end
+    end
+
     context 'when nested' do
       it 'defines a method that returns an instance of the class' do
         expect(wrapped.foo.bar).to be_a(SumakiSingularTest::Foo::Bar)
@@ -138,6 +151,19 @@ RSpec.describe Sumaki::Model::Associations do
 
     it 'sets the parent to the instances returned by the method it defines' do
       expect(wrapped.foo[0].parent).to be_a(SumakiRepeatedTest)
+    end
+
+    describe 'association#build' do
+      subject(:build) { wrapped.foo.build }
+
+      let(:wrapped) { SumakiRepeatedTest.new({}) }
+
+      it { is_expected.to be_a(SumakiRepeatedTest::Foo) }
+
+      it do
+        build
+        expect(wrapped.foo).to match([be_an_instance_of(SumakiRepeatedTest::Foo)])
+      end
     end
 
     context 'when nested' do

--- a/spec/sumaki/model/attribute_spec.rb
+++ b/spec/sumaki/model/attribute_spec.rb
@@ -122,4 +122,28 @@ RSpec.describe Sumaki::Model::Attribute do
       end
     end
   end
+
+  describe 'getter' do
+    subject { model.foo }
+
+    let(:klass) do
+      Class.new do
+        include Sumaki::Model
+
+        field :foo
+      end
+    end
+
+    context "when the value doesn't exist" do
+      let(:model) { klass.new({}) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the value exists' do
+      let(:model) { klass.new({ foo: 'value' }) }
+
+      it { is_expected.to eq('value') }
+    end
+  end
 end

--- a/spec/sumaki/model/attribute_spec.rb
+++ b/spec/sumaki/model/attribute_spec.rb
@@ -146,4 +146,38 @@ RSpec.describe Sumaki::Model::Attribute do
       it { is_expected.to eq('value') }
     end
   end
+
+  describe 'setter' do
+    subject(:set) { model.foo = 'new value' }
+
+    let(:klass) do
+      Class.new do
+        include Sumaki::Model
+
+        field :foo
+      end
+    end
+
+    context "when the value doesn't exist" do
+      let(:model) { klass.new({}) }
+
+      it { is_expected.to eq('new value') }
+
+      it do
+        set
+        expect(model.object).to eq({ foo: 'new value' })
+      end
+    end
+
+    context 'when the value exists' do
+      let(:model) { klass.new({ foo: 'old value' }) }
+
+      it { is_expected.to eq('new value') }
+
+      it do
+        set
+        expect(model.object).to eq({ foo: 'new value' })
+      end
+    end
+  end
 end

--- a/spec/sumaki/model/enum_spec.rb
+++ b/spec/sumaki/model/enum_spec.rb
@@ -12,5 +12,16 @@ RSpec.describe Sumaki::Model::Enum do
 
       it { expect(wrapped.type.name).to eq(:b) }
     end
+
+    describe 'setter' do
+      subject(:type_name) do
+        wrapped.type = 2
+        wrapped.type.name
+      end
+
+      let(:wrapped) { SumakiEnumTest.new({}) }
+
+      it { expect(type_name).to eq(:b) }
+    end
   end
 end


### PR DESCRIPTION
Add setters to Model.

```ruby
class Anime
  include Sumaki::Model

  singular :studio
  repeated :cast
  enum :genre, { shonen: 1, shojo: 2, seinen: 3 }
  field :name

  class Studio
    include Sumaki::Model

    field :name
  end

  class Cast
    include Sumaki::Model

    field :name
  end
end

anime = Anime.new({})

# Set a value to the field
anime.name = 'The Vampire Dies in No Time'

# Build a singular model
anime.build_studio(name: 'MADHOUSE Inc.')
anime.studio #=> #<Anime::Studio:0x00007ac3d9b7e8b0 name: "MADHOUSE Inc.">

# Build a repeated model
anime.cast.build(name: 'Furukawa Makoto')
anime.cast #=> [#<Anime::Cast:0x00007ac3d9b66f30 name: "Furukawa Makoto">]

# Set a enum value
anime.genre = 1
anime.genre.name #=> :shonen
```