### PR TITLE
Type casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ anime.title #=> 'The Vampire Dies in No Time'
 
 If the data contains attributes not declared in the field, it raises no error and is simply ignored.
 
+#### Type casting
+
+When a type is specified, it will be typecast.
+
+```ruby
+class Character
+  include Sumaki::Model
+
+  field :age, :int
+end
+
+character = Character.new({ age: '208' })
+character.age #=> 208
+```
+
+Types are:
+
+* `:int`
+* `:float`
+* `:string`
+* `:bool`
+* `:date`
+* `:datetime`
+
 ### Access to the sub object
 
 By declaring `singular`, you can access the sub object.

--- a/lib/sumaki/model/fields.rb
+++ b/lib/sumaki/model/fields.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'fields/reflection'
+
 module Sumaki
   module Model
     # = Sumaki::Model::Fields
@@ -24,9 +26,11 @@ module Sumaki
       end
 
       module AccessorAdder # :nodoc:
-        def add(methods_module, field_name)
-          add_getter(methods_module, field_name)
-          add_setter(methods_module, field_name)
+        def add(model_class, methods_module, reflection)
+          add_getter(methods_module, reflection.name)
+          add_setter(methods_module, reflection.name)
+
+          model_class.field_reflections[reflection.name] = reflection
         end
 
         def add_getter(methods_module, field_name)
@@ -66,12 +70,16 @@ module Sumaki
         #   anime.title = 'The Vampire Dies in No Time'
         #   anime.title #=> 'The Vampire Dies in No Time'
         def field(name)
-          field_names << name.to_sym
-          AccessorAdder.add(attribute_methods_module, name)
+          reflection = Reflection.new(name)
+          AccessorAdder.add(self, attribute_methods_module, reflection)
         end
 
         def field_names
-          @field_names ||= []
+          field_reflections.keys
+        end
+
+        def field_reflections
+          @field_reflections ||= {}
         end
 
         private

--- a/lib/sumaki/model/fields/reflection.rb
+++ b/lib/sumaki/model/fields/reflection.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
+require_relative 'type'
+
 module Sumaki
   module Model
     module Fields
       class Reflection # :nodoc:
-        def initialize(name)
+        def initialize(name, type = nil)
           @name = name
+          @type = type
         end
 
         def name
           @name.to_sym
+        end
+
+        def type_class
+          @type_class ||= @type.nil? ? Type::Value : Type.lookup(@type)
         end
       end
     end

--- a/lib/sumaki/model/fields/reflection.rb
+++ b/lib/sumaki/model/fields/reflection.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Sumaki
+  module Model
+    module Fields
+      class Reflection # :nodoc:
+        def initialize(name)
+          @name = name
+        end
+
+        def name
+          @name.to_sym
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type.rb
+++ b/lib/sumaki/model/fields/type.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative 'type/value'
+require_relative 'type/integer'
+require_relative 'type/float'
+require_relative 'type/string'
+require_relative 'type/boolean'
+require_relative 'type/date'
+require_relative 'type/date_time'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type # :nodoc:
+        class Types # :nodoc:
+          def initialize
+            @types = {}
+          end
+
+          def register(name, type_class)
+            @types[name] = type_class
+          end
+
+          def lookup(type_name)
+            @types.fetch(type_name)
+          end
+        end
+
+        @types = Types.new
+
+        def register(...)
+          @types.register(...)
+        end
+
+        def lookup(...)
+          @types.lookup(...)
+        end
+
+        module_function :register, :lookup
+
+        register(:int, Integer)
+        register(:float, Float)
+        register(:string, String)
+        register(:bool, Boolean)
+        register(:date, Date)
+        register(:datetime, DateTime)
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/boolean.rb
+++ b/lib/sumaki/model/fields/type/boolean.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class Boolean < Value # :nodoc:
+          def self.serialize(value)
+            return if value.nil?
+
+            case value
+            when true  then true
+            when false then false
+            else
+              raise ArgumentError
+            end
+          end
+
+          def self.deserialize(value)
+            case value
+            when true  then true
+            when false then false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/date.rb
+++ b/lib/sumaki/model/fields/type/date.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+require 'date'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class DateError < Error; end
+
+        class Date < Value # :nodoc:
+          def self.serialize(value)
+            value.nil? ? nil : cast(value)
+          rescue ::Date::Error
+            raise DateError
+          end
+
+          def self.deserialize(value)
+            value.nil? ? nil : cast(value)
+          rescue ::Date::Error
+            nil
+          end
+
+          def self.cast(value)
+            return value.to_date if value.respond_to?(:to_date)
+
+            ::Date.parse(value.to_s)
+          end
+          private_class_method :cast
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/date_time.rb
+++ b/lib/sumaki/model/fields/type/date_time.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+require 'date'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class DateError < Error; end
+
+        class DateTime < Value # :nodoc:
+          def self.serialize(value)
+            value.nil? ? nil : cast(value)
+          rescue ::Date::Error
+            raise DateError
+          end
+
+          def self.deserialize(value)
+            value.nil? ? nil : cast(value)
+          rescue ::Date::Error
+            nil
+          end
+
+          def self.cast(value)
+            return value.to_datetime if value.respond_to?(:to_datetime)
+
+            ::DateTime.parse(value.to_s)
+          end
+          private_class_method :cast
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/float.rb
+++ b/lib/sumaki/model/fields/type/float.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class Float < Value # :nodoc:
+          def self.serialize(value)
+            try_casting do
+              value.nil? ? nil : Float(value)
+            end
+          end
+
+          def self.deserialize(value)
+            value.nil? ? nil : Float(value, exception: false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/integer.rb
+++ b/lib/sumaki/model/fields/type/integer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class Integer < Value # :nodoc:
+          def self.serialize(value)
+            try_casting do
+              value.nil? ? nil : Integer(value)
+            end
+          end
+
+          def self.deserialize(value)
+            value.nil? ? nil : Integer(value, exception: false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/string.rb
+++ b/lib/sumaki/model/fields/type/string.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class String < Value # :nodoc:
+          def self.serialize(value)
+            try_casting do
+              value.nil? ? nil : String(value)
+            end
+          end
+
+          def self.deserialize(value)
+            value.nil? ? nil : String(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sumaki/model/fields/type/value.rb
+++ b/lib/sumaki/model/fields/type/value.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Sumaki
+  module Model
+    module Fields
+      module Type
+        class Error < StandardError; end
+        class ArgumentError < Error; end
+        class TypeError < Error; end
+
+        class Value # :nodoc:
+          def self.serialize(value)
+            value
+          end
+
+          def self.deserialize(value)
+            value
+          end
+
+          def self.try_casting
+            yield
+          rescue ::ArgumentError
+            raise Type::ArgumentError
+          rescue ::TypeError
+            raise Type::TypeError
+          end
+          private_class_method :try_casting
+        end
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/reflection_spec.rb
+++ b/spec/sumaki/model/fields/reflection_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sumaki::Model::Fields::Reflection do
+  describe '#type_class' do
+    subject { reflection.type_class }
+
+    let(:reflection) { described_class.new(:field, type) }
+
+    context 'when the type is :int' do
+      let(:type) { :int }
+
+      it { is_expected.to eq(Sumaki::Model::Fields::Type::Integer) }
+    end
+
+    context 'when the type is nil' do
+      let(:type) { nil }
+
+      it { is_expected.to eq(Sumaki::Model::Fields::Type::Value) }
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/boolean_spec.rb
+++ b/spec/sumaki/model/fields/type/boolean_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/boolean'
+
+RSpec.describe Sumaki::Model::Fields::Type::Boolean do
+  describe '.serialize' do
+    subject(:serialize) { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      [true, true],
+      [false, false]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    context 'when the value is a string can not be converted' do
+      let(:value) { 'abc' }
+
+      it { expect { serialize }.to raise_error(Sumaki::Model::Fields::Type::ArgumentError) }
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      [true, true],
+      [false, false],
+      ['abc', nil]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/boolean_spec.rb
+++ b/spec/sumaki/model/fields/type/boolean_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/boolean'
 
 RSpec.describe Sumaki::Model::Fields::Type::Boolean do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/date_spec.rb
+++ b/spec/sumaki/model/fields/type/date_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/date'
+
+RSpec.describe Sumaki::Model::Fields::Type::Date do
+  describe '.serialize' do
+    subject(:serialize) { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      [Date.new(2024, 1, 23), Date.new(2024, 1, 23)],
+      [DateTime.new(2024, 1, 23, 12, 34, 56), Date.new(2024, 1, 23)]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    context 'when the value is a string can not be converted' do
+      let(:value) { 'abc' }
+
+      it { expect { serialize }.to raise_error(Sumaki::Model::Fields::Type::DateError) }
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      [Date.new(2024, 1, 23), Date.new(2024, 1, 23)],
+      [DateTime.new(2024, 1, 23, 12, 34, 56), Date.new(2024, 1, 23)],
+      ['abc', nil]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/date_spec.rb
+++ b/spec/sumaki/model/fields/type/date_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/date'
 
 RSpec.describe Sumaki::Model::Fields::Type::Date do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/date_time_spec.rb
+++ b/spec/sumaki/model/fields/type/date_time_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/date_time'
 
 RSpec.describe Sumaki::Model::Fields::Type::DateTime do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/date_time_spec.rb
+++ b/spec/sumaki/model/fields/type/date_time_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/date_time'
+
+RSpec.describe Sumaki::Model::Fields::Type::DateTime do
+  describe '.serialize' do
+    subject(:serialize) { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      [DateTime.new(2024, 1, 23, 12, 34, 56), DateTime.new(2024, 1, 23, 12, 34, 56)],
+      [Date.new(2024, 1, 23), DateTime.new(2024, 1, 23)]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    context 'when the value is a string can not be converted' do
+      let(:value) { 'abc' }
+
+      it { expect { serialize }.to raise_error(Sumaki::Model::Fields::Type::DateError) }
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      [DateTime.new(2024, 1, 23, 12, 34, 56), DateTime.new(2024, 1, 23, 12, 34, 56)],
+      [Date.new(2024, 1, 23), DateTime.new(2024, 1, 23)],
+      ['abc', nil]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/float_spec.rb
+++ b/spec/sumaki/model/fields/type/float_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/float'
 
 RSpec.describe Sumaki::Model::Fields::Type::Float do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/float_spec.rb
+++ b/spec/sumaki/model/fields/type/float_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/float'
+
+RSpec.describe Sumaki::Model::Fields::Type::Float do
+  describe '.serialize' do
+    subject(:serialize) { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      [123.4, 123.4],
+      ['123.4', 123.4]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    context 'when the value is a string can not be converted' do
+      let(:value) { 'abc' }
+
+      it { expect { serialize }.to raise_error(Sumaki::Model::Fields::Type::ArgumentError) }
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      [123.4, 123.4],
+      ['123.4', 123.4],
+      ['abc', nil]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/integer_spec.rb
+++ b/spec/sumaki/model/fields/type/integer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/integer'
 
 RSpec.describe Sumaki::Model::Fields::Type::Integer do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/integer_spec.rb
+++ b/spec/sumaki/model/fields/type/integer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/integer'
+
+RSpec.describe Sumaki::Model::Fields::Type::Integer do
+  describe '.serialize' do
+    subject(:serialize) { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      [123, 123],
+      ['123', 123]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    context 'when the value is a string can not be converted' do
+      let(:value) { 'abc' }
+
+      it { expect { serialize }.to raise_error(Sumaki::Model::Fields::Type::ArgumentError) }
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      [123, 123],
+      ['123', 123],
+      ['abc', nil]
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/string_spec.rb
+++ b/spec/sumaki/model/fields/type/string_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/string'
+
+RSpec.describe Sumaki::Model::Fields::Type::String do
+  describe '.serialize' do
+    subject { described_class.serialize(value) }
+
+    [
+      [nil, nil],
+      %w[abc abc],
+      [123, '123']
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(value) }
+
+    [
+      [nil, nil],
+      %w[abc abc],
+      [123, '123']
+    ].each do |actual, expected|
+      context "when the value is #{actual.inspect}" do
+        let(:value) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type/string_spec.rb
+++ b/spec/sumaki/model/fields/type/string_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/string'
 
 RSpec.describe Sumaki::Model::Fields::Type::String do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/value_spec.rb
+++ b/spec/sumaki/model/fields/type/value_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type/value'
 
 RSpec.describe Sumaki::Model::Fields::Type::Value do
   describe '.serialize' do

--- a/spec/sumaki/model/fields/type/value_spec.rb
+++ b/spec/sumaki/model/fields/type/value_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type/value'
+
+RSpec.describe Sumaki::Model::Fields::Type::Value do
+  describe '.serialize' do
+    subject { described_class.serialize(:a_value) }
+
+    it { is_expected.to eq(:a_value) }
+  end
+
+  describe '.deserialize' do
+    subject { described_class.deserialize(:a_value) }
+
+    it { is_expected.to eq(:a_value) }
+  end
+end

--- a/spec/sumaki/model/fields/type_spec.rb
+++ b/spec/sumaki/model/fields/type_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sumaki/model/fields/type'
+
+RSpec.describe Sumaki::Model::Fields::Type do
+  describe '.lookup' do
+    subject { described_class.lookup(type_name) }
+
+    [
+      [:int, Sumaki::Model::Fields::Type::Integer],
+      [:float, Sumaki::Model::Fields::Type::Float],
+      [:string, Sumaki::Model::Fields::Type::String],
+      [:bool, Sumaki::Model::Fields::Type::Boolean],
+      [:date, Sumaki::Model::Fields::Type::Date],
+      [:datetime, Sumaki::Model::Fields::Type::DateTime]
+    ].each do |actual, expected|
+      context "when #{actual.inspect} is specified" do
+        let(:type_name) { actual }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+end

--- a/spec/sumaki/model/fields/type_spec.rb
+++ b/spec/sumaki/model/fields/type_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sumaki/model/fields/type'
 
 RSpec.describe Sumaki::Model::Fields::Type do
   describe '.lookup' do

--- a/spec/sumaki/model/fields_spec.rb
+++ b/spec/sumaki/model/fields_spec.rb
@@ -35,59 +35,53 @@ RSpec.describe Sumaki::Model::Fields do
   end
 
   describe 'getter' do
-    subject { model.foo }
+    subject { klass.new({ foo: '123' }).foo }
 
     let(:klass) do
-      Class.new do
-        include Sumaki::Model
-
-        field :foo
-      end
+      c = Class.new { include Sumaki::Model }
+      c.field :foo, field_type
+      c
     end
 
-    context "when the value doesn't exist" do
-      let(:model) { klass.new({}) }
+    context 'when the field type is not specified' do
+      let(:field_type) { nil }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq('123') }
     end
 
-    context 'when the value exists' do
-      let(:model) { klass.new({ foo: 'value' }) }
+    context 'when the field type is specified' do
+      let(:field_type) { :int }
 
-      it { is_expected.to eq('value') }
+      it { is_expected.to eq(123) }
     end
   end
 
   describe 'setter' do
-    subject(:set) { model.foo = 'new value' }
+    subject(:set) { model.foo = '123' }
 
     let(:klass) do
-      Class.new do
-        include Sumaki::Model
-
-        field :foo
-      end
+      c = Class.new { include Sumaki::Model }
+      c.field :foo, field_type
+      c
     end
 
-    context "when the value doesn't exist" do
-      let(:model) { klass.new({}) }
+    let(:model) { klass.new({}) }
 
-      it { is_expected.to eq('new value') }
+    context 'when the field type is not specified' do
+      let(:field_type) { nil }
 
       it do
         set
-        expect(model.object).to eq({ foo: 'new value' })
+        expect(model.object).to eq({ foo: '123' })
       end
     end
 
-    context 'when the value exists' do
-      let(:model) { klass.new({ foo: 'old value' }) }
-
-      it { is_expected.to eq('new value') }
+    context 'when the field type is specified' do
+      let(:field_type) { :int }
 
       it do
         set
-        expect(model.object).to eq({ foo: 'new value' })
+        expect(model.object).to eq({ foo: 123 })
       end
     end
   end


### PR DESCRIPTION
If the type is specified as the second argument of `field`, it will be typecast.

```ruby
class Character
  include Sumaki::Model

  field :age, :int
end

character = Character.new({ age: '208' })
character.age #=> 208
```

Types are:

* `:int`
* `:float`
* `:string`
* `:bool`
* `:date`
* `:datetime`
